### PR TITLE
Fix applicationId to 'org.tensorflow.demo' (#12432)

### DIFF
--- a/tensorflow/examples/android/build.gradle
+++ b/tensorflow/examples/android/build.gradle
@@ -79,7 +79,7 @@ android {
 
     if (nativeBuildSystem == 'cmake') {
         defaultConfig {
-            applicationId = 'com.tensorflow.demo'
+            applicationId = 'org.tensorflow.demo'
             minSdkVersion 21
             targetSdkVersion 23
             ndk {


### PR DESCRIPTION
For nativeBuildSystem == 'cmake' change `applicationId = 'com.tensorflow.demo'` to `applicationId = 'org.tensorflow.demo'`
Otherwise Android system treat bult app (com.tensorflow.demo) as separate one and install it alonside to org.tensorflow.demo