### PR TITLE
Create a new pull request by comparing changes across two branches

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -309,9 +309,6 @@ build:linux --copt="-Wno-extra"
 build:linux --copt="-Wno-deprecated"
 build:linux --copt="-Wno-deprecated-declarations"
 build:linux --copt="-Wno-ignored-attributes"
-build:linux --copt="-Wno-unknown-warning"
-build:linux --copt="-Wno-array-parameter"
-build:linux --copt="-Wno-stringop-overflow"
 build:linux --copt="-Wno-array-bounds"
 
 # Add unused-result as an error on Linux.
@@ -320,6 +317,8 @@ build:linux --copt="-Werror=unused-result"
 # Add switch as an error on Linux.
 build:linux --copt="-Wswitch"
 build:linux --copt="-Werror=switch"
+# Required for building with clang
+build:linux --copt="-Wno-error=unused-but-set-variable"
 
 # On Windows, `__cplusplus` is wrongly defined without this switch
 # See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/

--- a/tensorflow/core/public/version.h
+++ b/tensorflow/core/public/version.h
@@ -108,7 +108,7 @@ limitations under the License.
 
 #define TF_GRAPH_DEF_VERSION_MIN_PRODUCER 0
 #define TF_GRAPH_DEF_VERSION_MIN_CONSUMER 0
-#define TF_GRAPH_DEF_VERSION 1334  // Updated: 2022/12/3
+#define TF_GRAPH_DEF_VERSION 1335  // Updated: 2022/12/4
 
 // Checkpoint compatibility versions (the versions field in SavedSliceMeta).
 //

--- a/tensorflow/python/compat/compat.py
+++ b/tensorflow/python/compat/compat.py
@@ -29,7 +29,7 @@ from tensorflow.python.util.tf_export import tf_export
 # This value changes every day with an automatic CL. It can be modified in code
 # via `forward_compatibility_horizon()` or with the environment variable
 # TF_FORWARD_COMPATIBILITY_DELTA_DAYS, which is added to the compatibility date.
-_FORWARD_COMPATIBILITY_HORIZON = datetime.date(2022, 12, 3)
+_FORWARD_COMPATIBILITY_HORIZON = datetime.date(2022, 12, 4)
 _FORWARD_COMPATIBILITY_DELTA_DAYS_VAR_NAME = "TF_FORWARD_COMPATIBILITY_DELTA_DAYS"
 _FORWARD_COMPATIBILITY_DATE_NUMBER = None
 


### PR DESCRIPTION
Removes GCC specific configs from bazelrc. Adds a config required to build with clang.

PiperOrigin-RevId: 492677290